### PR TITLE
[IMP] base_geoengine: allow custom configuration on layer opacity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,18 @@ env:
   - TESTS="1" ODOO_REPO="odoo/odoo" LINT_CHECK="0" MAKEPOT="1"
   - TESTS="1" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
 
+before_install:
+
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install geojson Shapely sphinx sphinx_bootstrap_theme sphinx-intl odoo-sphinx-autodoc
+  # This is to solve an issue with stdout file descriptor
+  # raising a BlockingIOError while executing pylint and returns an exit -1
+  # seems related to the numerous lint errors on web_view_google_map module
+  # https://github.com/travis-ci/travis-ci/issues/8920
+  - /usr/bin/env python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 
 before_script:
   - psql -U postgres -d postgres -c "create extension postgis"

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Available addons
 ----------------
 addon | version | summary
 --- | --- | ---
-[base_geoengine](base_geoengine/) | 10.0.2.0.1 | Geospatial support for Odoo
-[base_geoengine_demo](base_geoengine_demo/) | 10.0.1.0.0 | Geo spatial support Demo
-[geoengine_partner](geoengine_partner/) | 10.0.1.0.0 | Geospatial support of partners
+[base_geoengine](base_geoengine/) | 10.0.2.0.2 | Geospatial support for Odoo
+[base_geoengine_demo](base_geoengine_demo/) | 10.0.1.0.1 | Geo spatial support Demo
+[geoengine_partner](geoengine_partner/) | 10.0.1.0.1 | Geospatial support of partners
 
 
 Unported addons

--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Geospatial support for Odoo',
-    'version': '10.0.2.0.1',
+    'version': '10.0.2.0.2',
     'category': 'GeoBI',
     'author': "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     'license': 'AGPL-3',

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -61,6 +61,11 @@ var formatFeatureHTML = function(a, fields) {
             if (fields.hasOwnProperty(key)) {
                 var field = fields[key];
                 var label = field.string;
+
+                if (field.type.startsWith('geo_')) {
+                    continue;
+                }
+
                 if (field.type === 'selection') {
                     // get display value of selection option
                     for (var option in field.selection) {
@@ -416,12 +421,13 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 });
                 var olStyleText = new ol.style.Text({
                     text: "",
+                    font: '12px Arial',
                     fill: new ol.style.Fill({
                       color: "#000000"
                     }),
                     stroke: new ol.style.Stroke({
                       color: "#FFFFFF",
-                      width: 2
+                      width: 10
                     })
                 });
                 var styles = [

--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -34,11 +34,12 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
     create_vector_layer: function(self) {
         this.features = new ol.Collection();
         this.source = new ol.source.Vector({features: this.features});
-        return new ol.layer.Vector({
+
+        var vl = new ol.layer.Vector({
             source: this.source,
             style: new ol.style.Style({
                 fill: new ol.style.Fill({
-                    color: '#ee9900',
+                    color: (!!this.options && this.options.fill_color) ?  this.options.fill_color :'#ee9900',
                     opacity: 0.7,
                 }),
                 stroke: new ol.style.Stroke({
@@ -54,10 +55,17 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
                 }),
             })
         });
+
+        if (!!this.options && this.options.opacity) {
+            vl.setOpacity(this.options.opacity)
+        }
+        
+        return vl;
     },
 
     create_layers: function(self, field_infos) {
         this.vector_layer = this.create_vector_layer();
+
         this.raster_layers = this.createBackgroundLayers([field_infos.edit_raster]);
         this.raster_layers[0].isBaseLayer = true;
     },

--- a/base_geoengine/tests/test_geoengine.py
+++ b/base_geoengine/tests/test_geoengine.py
@@ -27,7 +27,7 @@ _logger = logging.getLogger(__name__)
 class TestGeoengine(common.TransactionCase):
 
     def setUp(self):
-        common.TransactionCase.setUp(self)
+        super(TestGeoengine, self).setUp()
 
         class DummyModel(GeoModel):
             _name = 'test.dummy'

--- a/base_geoengine_demo/__manifest__.py
+++ b/base_geoengine_demo/__manifest__.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2012 Nicolas Bessi (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {'name': 'Geo spatial support Demo',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'category': 'GeoBI',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'license': 'AGPL-3',

--- a/base_geoengine_demo/models/retail_machine.py
+++ b/base_geoengine_demo/models/retail_machine.py
@@ -1,11 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright 2011-2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import geojson
+import logging
 
 from odoo import api, fields
 from odoo.addons.base_geoengine import geo_model
 from odoo.addons.base_geoengine import fields as geo_fields
+
+
+logger = logging.getLogger(__name__)
+try:
+    import geojson
+except ImportError:
+    logger.warning('geojson is not available in the sys path')
 
 
 class RetailMachine(geo_model.GeoModel):

--- a/base_geoengine_demo/views/zip.xml
+++ b/base_geoengine_demo/views/zip.xml
@@ -16,7 +16,7 @@
         </group>
         <notebook colspan="4">
           <page string="Geometry">
-            <field name="the_geom" colspan="4" widget="geo_edit_map"/>
+            <field name="the_geom" colspan="4" widget="geo_edit_map" options='{"opacity": 0.4, "fill_color":"#33ccff"}'/>
           </page>
         </notebook>
         <field name="total_sales"/>

--- a/geoengine_partner/__manifest__.py
+++ b/geoengine_partner/__manifest__.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 {'name': 'Geospatial support of partners',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'category': 'GeoBI',
  'author': "Camptocamp, Odoo Community Association (OCA)",
  'license': 'AGPL-3',

--- a/geoengine_partner/views/partner.xml
+++ b/geoengine_partner/views/partner.xml
@@ -47,25 +47,6 @@
         <field name="geo_repr">basic</field>
         <field eval="1" name="nb_class"/>
         <field name="begin_color">#FF680A</field>
-        <field name="symbol_binary">iVBORw0KGgoAAAANSUhEUgAAACAAAAAfCAYAAACGVs+MAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
-            bWFnZVJlYWR5ccllPAAAA3VJREFUeNq8V89rE0EUfjOz6aZNpFZpqyCEIooHoVaoQkGoB3vyJB49
-            iYieFERBEMRbxYP/gFcv3ntQLHqwqNR6LNUqIq0/m8S2u0l3NzszfpNsqN0e3MiuA4/Jmx3e++Z7
-            3/wI01pTkvZicF+zzwvR1c35efRX0B/K7SgScUHScVZ8KR96St31pPyuEHfk6+e/xrUoYWMwQM3D
-            7gvOL9lIYA8MkD1+gli+hxozM/3qw8erHtEYpp7D/MUkcXlSAFiZUEQXEfgSiwCJvp0kDh8mcWSY
-            2J49xBkzAY8B5KSvdTFVAKHWJan1dVMwQy/AkCyXKZydo8bLVySXl0kqZVgizDvT0Ho0SdzEJUDA
-            CaH1XgQ3YCjgnESlSmp6uqmBsFajoDWPmnOUOgX3WXoAlBoFxSLAKgWoZjDDhLXuNMsRwg/gQ4Bm
-            rvldSpUBrPoXR3CvLUgka4AFi7eqqExijPlmjmFISi9VDaA9xqoCiJHqSGKsBnPDkGowNxrbiL77
-            Sr1JlQG017DnCDzR1oFol6MlvKYZFlCCCsT4JG0A67CbsGEkHzSK520KAcIkp2h3oN2CfUy7BKa9
-            hZ2FzWnPo7BepwB9gF7ClKYKvl2GPUgaMDEDGtusfSrr0J+g42PXVLF4Uy8vM76rj6hQmKKn0zeY
-            EPOdrCgxAOvk+KazsVGlC+cf2fv3X+sOQ9uT5gDSU9q25ynh3dIxgO47t/+4GBhpxwn3Fgu6NFSi
-            paUv5Ky7gXVvcvPWSBsAd92tJdF6FQeRr0KZ1+YI1mpNrq5Rpy2xCBnjcYPgWOWP6/wH/UNLzEBX
-            Vy7OQIBKrEbpfVglUwCFnp44AI0jyI3KXYfb0B0KsLNtGBNW02fUFsaGuS4yZcDUPQZJY+xnpHgH
-            FmQKgHMWS48xRu1H3zdThmwBxBgwJcBYNXLL5tWWMQM8LkJinDuR62ZeAhYrQVODnK1H0jQXhcwU
-            gBBia35cfWClbJDgeeaADcPIfwTA8SARAKCb5Slb+M6zBLBNA62dYYSn8UdlNWdZ2QLo6+vdNibx
-            LAIQF+z4tp3ftlVTBVBZqcZPJurv3x16nv+jt7fXd/FgaYQNar0QMwDw6dPSFt+svVqt+iMjw3Jh
-            4X24Ui2Tldt6YR06eCDFF5Flxc+B00g8/G5xYVYF6ui+odIOzHmI8Y62428BBgDwu9RGZbaLEwAA
-            AABJRU5ErkJggg==
-        </field>
     </record>
     <record id="geoengine_raster_layer_res_partner_osm" model="geoengine.raster.layer">
         <field name="raster_type">osm</field>

--- a/geoengine_project/views/geo_project_view.xml
+++ b/geoengine_project/views/geo_project_view.xml
@@ -43,25 +43,6 @@
             <field name="geo_repr">basic</field>
             <field eval="1" name="nb_class"/>
             <field name="begin_color">#FF680A</field>
-            <field name="symbol_binary">iVBORw0KGgoAAAANSUhEUgAAACAAAAAfCAYAAACGVs+MAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
-                bWFnZVJlYWR5ccllPAAAA3VJREFUeNq8V89rE0EUfjOz6aZNpFZpqyCEIooHoVaoQkGoB3vyJB49
-                iYieFERBEMRbxYP/gFcv3ntQLHqwqNR6LNUqIq0/m8S2u0l3NzszfpNsqN0e3MiuA4/Jmx3e++Z7
-                3/wI01pTkvZicF+zzwvR1c35efRX0B/K7SgScUHScVZ8KR96St31pPyuEHfk6+e/xrUoYWMwQM3D
-                7gvOL9lIYA8MkD1+gli+hxozM/3qw8erHtEYpp7D/MUkcXlSAFiZUEQXEfgSiwCJvp0kDh8mcWSY
-                2J49xBkzAY8B5KSvdTFVAKHWJan1dVMwQy/AkCyXKZydo8bLVySXl0kqZVgizDvT0Ho0SdzEJUDA
-                CaH1XgQ3YCjgnESlSmp6uqmBsFajoDWPmnOUOgX3WXoAlBoFxSLAKgWoZjDDhLXuNMsRwg/gQ4Bm
-                rvldSpUBrPoXR3CvLUgka4AFi7eqqExijPlmjmFISi9VDaA9xqoCiJHqSGKsBnPDkGowNxrbiL77
-                Sr1JlQG017DnCDzR1oFol6MlvKYZFlCCCsT4JG0A67CbsGEkHzSK520KAcIkp2h3oN2CfUy7BKa9
-                hZ2FzWnPo7BepwB9gF7ClKYKvl2GPUgaMDEDGtusfSrr0J+g42PXVLF4Uy8vM76rj6hQmKKn0zeY
-                EPOdrCgxAOvk+KazsVGlC+cf2fv3X+sOQ9uT5gDSU9q25ynh3dIxgO47t/+4GBhpxwn3Fgu6NFSi
-                paUv5Ky7gXVvcvPWSBsAd92tJdF6FQeRr0KZ1+YI1mpNrq5Rpy2xCBnjcYPgWOWP6/wH/UNLzEBX
-                Vy7OQIBKrEbpfVglUwCFnp44AI0jyI3KXYfb0B0KsLNtGBNW02fUFsaGuS4yZcDUPQZJY+xnpHgH
-                FmQKgHMWS48xRu1H3zdThmwBxBgwJcBYNXLL5tWWMQM8LkJinDuR62ZeAhYrQVODnK1H0jQXhcwU
-                gBBia35cfWClbJDgeeaADcPIfwTA8SARAKCb5Slb+M6zBLBNA62dYYSn8UdlNWdZ2QLo6+vdNibx
-                LAIQF+z4tp3ftlVTBVBZqcZPJurv3x16nv+jt7fXd/FgaYQNar0QMwDw6dPSFt+svVqt+iMjw3Jh
-                4X24Ui2Tldt6YR06eCDFF5Flxc+B00g8/G5xYVYF6ui+odIOzHmI8Y62428BBgDwu9RGZbaLEwAA
-                AABJRU5ErkJggg==
-            </field>
         </record>
 
         <record id="geoengine_raster_layer_project_project"


### PR DESCRIPTION
into the view definition, you can now specify 2 options on the geofield. Opacity (for the layer) and a fill_color
ex:
<field name="geofield" widget="geo_edit_map"
 options='{"opacity": 0.4, "fill_color":"#33ccff"}'/>